### PR TITLE
feat: remove hdi plugin versions as not needed

### DIFF
--- a/ide-migration/server/migration/api/migration-service.js
+++ b/ide-migration/server/migration/api/migration-service.js
@@ -67,20 +67,16 @@ class MigrationService {
         const hdiConfig = {
             file_suffixes: {
                 hdbcalculationview: {
-                    plugin_name: "com.sap.hana.di.calculationview",
-                    plugin_version: "12.1.0"
+                    plugin_name: "com.sap.hana.di.calculationview"
                 },
                 calculationview: {
-                    plugin_name: "com.sap.hana.di.calculationview",
-                    plugin_version: "12.1.0"
+                    plugin_name: "com.sap.hana.di.calculationview"
                 },
                 hdbanalyticprivilege: {
-                    plugin_name: "com.sap.hana.di.analyticprivilege",
-                    plugin_version: "12.1.0"
+                    plugin_name: "com.sap.hana.di.analyticprivilege"
                 },
                 analyticprivilege: {
-                    plugin_name: "com.sap.hana.di.analyticprivilege",
-                    plugin_version: "12.1.0"
+                    plugin_name: "com.sap.hana.di.analyticprivilege"
                 }
             }
         };


### PR DESCRIPTION
As discussed offline, it seems the plugin versions are not needed. This PR removes them for all HDI plugins.