### PR TITLE
fix: move tablefunction synonym to hdbpublicsynonym file

### DIFF
--- a/ide-migration/server/migration/api/migration-service.mjs
+++ b/ide-migration/server/migration/api/migration-service.mjs
@@ -27,7 +27,7 @@ export class MigrationService {
 
     synonymFileName = "hdi-synonyms.hdbsynonym";
     publicSynonymFileName = "hdi-public-synonyms.hdbpublicsynonym";
-    fileExtsForHDI = [".hdbcalculationview", ".calculationview", ".analyticprivilege", ".hdbanalyticprivilege", ".hdbflowgraph"];
+    fileExtsForHDI = [".hdbcalculationview", ".calculationview", ".analyticprivilege", ".hdbanalyticprivilege", ".hdbflowgraph", ".hdbtablefunction"];
 
     setupConnection(databaseName, databaseUser, databaseUserPassword, connectionUrl) {
         database.createDataSource(databaseName, "com.sap.db.jdbc.Driver", connectionUrl, databaseUser, databaseUserPassword, null);


### PR DESCRIPTION
The tablefunction synonym was being generated in *.hdbsynonym, not *.hdbpublicsynonym
:warning: Merge with https://github.com/SAP/xsk/pull/1393