### PR TITLE
Generate synonym for resources from external schema

### DIFF
--- a/ide-migration/js/zip-migration.js
+++ b/ide-migration/js/zip-migration.js
@@ -10,7 +10,6 @@ migrationLaunchView.controller("ImportZippedDU", [
     function ($scope, $http, FileUploader, $messageHub, migrationViewState, migrationFlow) {
         $scope.TRANSPORT_PROJECT_URL = "/services/v4/transport/project";
         $scope.WORKSPACES_URL = "/services/v4/ide/workspaces";
-        $scope.TEMP_MIGRATION_ROOT = "temp/migrations/";
         $scope.zipPaths = [];
         $scope.migrationFinished = false;
         $scope.stepIndex = 1;
@@ -31,8 +30,12 @@ migrationLaunchView.controller("ImportZippedDU", [
             }
         });
         $scope.projectFromZipPath = function (zipname = "") {
-            return $scope.TEMP_MIGRATION_ROOT + $scope.selectedWs + "/" + zipname.split(".").slice(0, -1).join(".");
+            return $scope.selectedWs + "/" + zipname.split(".").slice(0, -1).join(".");
         };
+
+        $scope.workspacePath = function (zipname = "") {
+            return $scope.selectedWs + "/";
+        }
 
         // FILE UPLOADER
 
@@ -61,7 +64,7 @@ migrationLaunchView.controller("ImportZippedDU", [
         };
         $scope.uploader.onBeforeUploadItem = function (item) {
             console.info("onBeforeUploadItem", item);
-            item.url = $scope.TRANSPORT_PROJECT_URL + "?path=" + encodeURI($scope.projectFromZipPath(item.file.name));
+            item.url = $scope.TRANSPORT_PROJECT_URL + "?path=" + encodeURI($scope.workspacePath(item.file.name));
         };
         $scope.uploader.onProgressItem = function (fileItem, progress) {
             //        console.info('onProgressItem', fileItem, progress);

--- a/ide-migration/server/migration/api/hana-visitor.mjs
+++ b/ide-migration/server/migration/api/hana-visitor.mjs
@@ -11,6 +11,7 @@ export class HanaVisitor {
     fw_super;
     schemaRefs = [];
     viewRefs = [];
+    tableRefs = [];
     schemaSeparator = '"."';
     viewSeparator = "/";
 
@@ -34,6 +35,7 @@ export class HanaVisitor {
             },
             visitTableview_name: function (ctx) {
                 const text = ctx.getText();
+                that.addToTableRefs(text);
                 that.addToSchemaRefsIfNeeded(text);
                 return that.fw_super.visitChildren(ctx);
             },
@@ -56,6 +58,10 @@ export class HanaVisitor {
         if (text.split(this.viewSeparator).length > 1) {
             this.viewRefs.push(text.replace(/['"]+/g, ""));
         }
+    }
+
+    addToTableRefs(text) {
+        this.tableRefs.push(text.replace(/['"]+/g, ""));
     }
 
     visit() {

--- a/ide-migration/server/migration/api/migration-service.mjs
+++ b/ide-migration/server/migration/api/migration-service.mjs
@@ -20,6 +20,7 @@ const XSKProjectMigrationInterceptor = Java.type("com.sap.xsk.modificators.XSKPr
 const XSKHDBCoreFacade = Java.type("com.sap.xsk.hdb.ds.facade.XSKHDBCoreSynchronizationFacade");
 const hdbDDModel = "com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureCdsModel";
 const xskModificator = new XSKProjectMigrationInterceptor();
+const streams = org.eclipse.dirigible.api.v3.io.StreamsFacade;
 
 export class MigrationService {
     repo = null;
@@ -124,7 +125,7 @@ export class MigrationService {
 
         const projectNames = [];
         const synonyms = [];
-        const calcViews = [];
+        const calcViews = {};
 
         for (const file of lists) {
             let fileRunLocation = file.RunLocation;
@@ -177,7 +178,7 @@ export class MigrationService {
         const hdbFacade = new XSKHDBCoreFacade();
 
         const synonyms = [];
-        const calcViews = [];
+        const calcViews = {};
 
         const that = this;
 
@@ -234,10 +235,11 @@ export class MigrationService {
     }
 
     _handleCalculationViews(calcViews, synonyms, workspaceName) {
-        for (const key of calcViews) {
+        for (const key in calcViews) {
             if (calcViews.hasOwnProperty(key)) {
                 const resource = repositoryManager.getResource(key);
                 const fileProjectName = calcViews[key]
+                console.log(`Checking calcview: ${key}`)
                 this._generateSynonymsForExternalResources(resource.getContent(), synonyms, workspaceName, fileProjectName);
                 const newContent = this._transformColumnObject(resource.getContent(), synonyms);
                 resource.setContent(newContent);
@@ -264,7 +266,7 @@ export class MigrationService {
             const schema = dataSource.getAttribute('schemaName');
             if (localSynonyms.indexOf(`${schema}_${objectName}`) === -1) {
                 //create synonym
-                console.log("Generating synonym for calculation view...")
+                console.log("Generating synonym for calculation view... ");
                 const hdbSynonym = this._generateHdbSynonym(
                     objectName,
                     schema

--- a/ide-migration/server/migration/api/migration-service.mjs
+++ b/ide-migration/server/migration/api/migration-service.mjs
@@ -158,7 +158,7 @@ export class MigrationService {
             "role-template-references": ["$XSAPPNAME.Operator"]
         }];
         let lastProjectName = "";
-      
+
         for (const file of lists) {
             let fileRunLocation = file.RunLocation;
 
@@ -203,9 +203,7 @@ export class MigrationService {
                 this._buildXSSecurityElementsFromXSPrivileges(jsonContent, privilegePrefix, scopes, roleTemplates, roleCollections);
             }
 
-            const projectCollection = this._getOrCreateTemporaryProjectCollection(workspaceCollection, fileProjectName);
-            projectCollection.createResource(fileRunLocation, content);
-
+            lastProjectName = fileProjectName;
             const fileName = this._getFileNameWithExtension(file);
             const filePath = this._getAbsoluteFilePath(file);
             const fileContent = bytes.byteArrayToText(content);
@@ -213,6 +211,7 @@ export class MigrationService {
 
         }
         this._handleCalculationViews(calcViews, synonyms, workspaceName);
+        this._createXsSecurityJson(lastProjectName, scopes, roleTemplates, roleCollections);
         return { projectNames, synonyms };
     }
 
@@ -323,8 +322,6 @@ export class MigrationService {
             }
         }
         this._appendOrCreateSynonymsFile(this.synonymFileName, synonyms, workspaceName, fileProjectName);
-        lastProjectName = fileProjectName;
-        this._createXsSecurityJson(lastProjectName, scopes, roleTemplates, roleCollections);
     }
 
     _parseArtifact(fileName, filePath, fileContent, workspacePath, hdbFacade) {

--- a/ide-migration/server/migration/process/copy-files-task.mjs
+++ b/ide-migration/server/migration/process/copy-files-task.mjs
@@ -27,8 +27,9 @@ export class CopyFilesTask extends MigrationTask {
             const files = migrationService.getAllFilesForDU(deliveryUnit);
             if (files) {
                 const duName = deliveryUnit.name;
-                const projectNames = migrationService.copyFilesLocally(userData.workspace, duName, files);
+                const { projectNames, synonyms } = migrationService.copyFilesLocally(userData.workspace, duName, files);
                 deliveryUnit.projectNames = projectNames;
+                deliveryUnit.synonyms = synonyms;
             }
         }
 

--- a/ide-migration/server/migration/process/handle-deployables-task.mjs
+++ b/ide-migration/server/migration/process/handle-deployables-task.mjs
@@ -47,7 +47,7 @@ export class HandleDeployablesTask extends MigrationTask {
                 let synonymsPaths = [];
                 let projectsWithSynonyms = [];
 
-                const workspacePath = `${deliveryUnit.fromZip ? "temp/migrations/" : ""}${workspaceName}`
+                const workspacePath = workspaceName;
 
                 const repositoryPath = `${workspacePath}/${projectName}`;
                 const duRootCollection = repository.getCollection(repositoryPath);

--- a/ide-migration/server/migration/process/populate-projects-task.mjs
+++ b/ide-migration/server/migration/process/populate-projects-task.mjs
@@ -49,7 +49,7 @@ export class PopulateProjectsTask extends MigrationTask {
                 for (const generatedFile of generatedFiles) {
                     migrationService.addFileToWorkspace(workspaceName, generatedFile.repositoryPath, generatedFile.relativePath, generatedFile.projectName);
                 }
-                migrationService.handleHDBTableFunctions(workspaceName, projectName);
+                migrationService.handleHDBTableFunctions(workspaceName, projectName, deliveryUnit.synonyms);
 
                 //modify files
                 console.log("Modifying files...")

--- a/ide-migration/server/migration/process/populate-projects-task.mjs
+++ b/ide-migration/server/migration/process/populate-projects-task.mjs
@@ -25,7 +25,7 @@ export class PopulateProjectsTask extends MigrationTask {
 
             for (const projectName of deliveryUnit.projectNames) {
 
-                const workspacePath = `${deliveryUnit.fromZip ? "temp/migrations/" : ""}${workspaceName}`
+                const workspacePath = workspaceName;
 
                 const repositoryPath = `${workspacePath}/${projectName}`;
                 const duRootCollection = repositoryManager.getCollection(repositoryPath);

--- a/ide-migration/server/migration/process/unzip-to-temporary-folder-task.mjs
+++ b/ide-migration/server/migration/process/unzip-to-temporary-folder-task.mjs
@@ -12,6 +12,7 @@
 import { process } from "@dirigible/bpm"
 import { repository as repositoryManager } from "@dirigible/platform"
 import { MigrationTask } from "./task.mjs";
+import { MigrationService } from "../api/migration-service.mjs";
 
 export class UnzipToTemporaryFolder extends MigrationTask {
 	execution = process.getExecutionContext();
@@ -32,7 +33,19 @@ export class UnzipToTemporaryFolder extends MigrationTask {
 			let collection = repositoryManager.getCollection(path);
 
 			let zipProjectName = collection.getName();
-			userData.du.push(composeJson(zipProjectName))
+
+			const duObject = composeJson(zipProjectName);
+
+			const workspaceName = userData.workspace;
+
+			const migrationService = new MigrationService();
+			try {
+				migrationService.generateSynonymsForProject(workspaceName, zipProjectName);
+			} catch (err) {
+				console.log(`Error generating synonyms for zip: ${err.message}`);
+			}
+
+			userData.du.push(duObject);
 		}
 		process.setVariable(this.execution.getId(), 'userData', JSON.stringify(userData));
 

--- a/ide-migration/server/migration/process/unzip-to-temporary-folder-task.mjs
+++ b/ide-migration/server/migration/process/unzip-to-temporary-folder-task.mjs
@@ -40,11 +40,14 @@ export class UnzipToTemporaryFolder extends MigrationTask {
 
 			const migrationService = new MigrationService();
 			try {
-				migrationService.generateSynonymsForProject(workspaceName, zipProjectName);
+				const { projectNames, synonyms } = migrationService.generateSynonymsForProject(workspaceName, zipProjectName);
+				duObject.projectNames = projectNames;
+				duObject.synonyms = synonyms;
 			} catch (err) {
 				console.log(`Error generating synonyms for zip: ${err.message}`);
 				console.log(err.stack)
 			}
+
 
 			userData.du.push(duObject);
 		}
@@ -65,6 +68,7 @@ export class UnzipToTemporaryFolder extends MigrationTask {
 			duObject.name = projectName;
 			duObject.projectNames = [projectName];
 			duObject.fromZip = true;
+			duObject.synonyms = [];
 			return duObject;
 		}
 

--- a/ide-migration/server/migration/process/unzip-to-temporary-folder-task.mjs
+++ b/ide-migration/server/migration/process/unzip-to-temporary-folder-task.mjs
@@ -43,6 +43,7 @@ export class UnzipToTemporaryFolder extends MigrationTask {
 				migrationService.generateSynonymsForProject(workspaceName, zipProjectName);
 			} catch (err) {
 				console.log(`Error generating synonyms for zip: ${err.message}`);
+				console.log(err.stack)
 			}
 
 			userData.du.push(duObject);


### PR DESCRIPTION
Implements https://github.com/SAP/xsk/issues/1224

1. For each synonym that is generated append *`${schemaName}_${schemaObject}`* in *synonyms* array
2. When all synonyms are created check all calculationviews' schema and object references. If they are not found in the *synonyms* array generate new synonyms.
3. Do the same with all tableviewnames collected by HanaVisitor.
